### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/hardware/memory/swap.c
+++ b/src/hardware/memory/swap.c
@@ -38,7 +38,7 @@ uint64_t allocate_swappage(uint64_t ppn)
     FILE *fw = fopen(filename, "w");
     assert(fw != NULL);
 
-    // write zero page for anoymous page
+    // write zero page for anonymous page
     // But there is no transaction actually
     fclose(fw);
     uint64_t ppn_ppo = ppn << PHYSICAL_PAGE_OFFSET_LENGTH;
@@ -64,7 +64,7 @@ int swap_in(uint64_t saddr, uint64_t ppn)
     {
         // saddr == 0 indicates that this page is not backed by file
         // nor backed by swap space. It should be a newly created 
-        // anoymous page. Allocate one swap address for it.
+        // anonymous page. Allocate one swap address for it.
         allocate_swappage(ppn);
         return 0;
     }

--- a/src/mains/mesi.c
+++ b/src/mains/mesi.c
@@ -118,7 +118,7 @@ int read_cacheline(int i, int *read_value)
     else
     {
         // read miss
-        // bus boardcast read miss
+        // bus broadcast read miss
         for (int j = 0; j < NUM_PROCESSOR; ++ j)
         {
             if (i != j)
@@ -126,7 +126,7 @@ int read_cacheline(int i, int *read_value)
                 if (cache[j].state == MODIFIED)
                 {
                     // write back
-                    // there are eaxctly 2 copies in processors
+                    // there are exactly 2 copies in processors
                     mem_value = cache[j].value;
                     cache[j].state = SHARED;
 
@@ -148,7 +148,7 @@ int read_cacheline(int i, int *read_value)
                     cache[i].state = SHARED;
                     cache[i].value = cache[j].value;
 
-                    // there are eaxctly 2 copies in processors
+                    // there are exactly 2 copies in processors
                     cache[j].state = SHARED;
 
                     *read_value = cache[i].value;
@@ -221,7 +221,7 @@ int write_cacheline(int i, int write_value)
     }
     else if (cache[i].state == SHARED)
     {
-        // boardcast write invalid
+        // broadcast write invalid
         for (int j = 0; j < NUM_PROCESSOR; j ++)
         {
             if (j != i)
@@ -235,7 +235,7 @@ int write_cacheline(int i, int write_value)
         cache[i].value = write_value;
 
 #ifdef DEBUG
-        printf("[%d] write hit; boardcast invalid; update to value %d\n", i, cache[i].value);
+        printf("[%d] write hit; broadcast invalid; update to value %d\n", i, cache[i].value);
 #endif
 
         return 1;
@@ -263,7 +263,7 @@ int write_cacheline(int i, int write_value)
                     cache[i].value = write_value;
 
 #ifdef DEBUG
-                    printf("[%d] write miss; boardcast invalid to M; update to value %d\n", i, cache[i].value);
+                    printf("[%d] write miss; broadcast invalid to M; update to value %d\n", i, cache[i].value);
 #endif
                     return 1;
                 }
@@ -276,7 +276,7 @@ int write_cacheline(int i, int write_value)
                     cache[i].value = write_value;
 
 #ifdef DEBUG
-                    printf("[%d] write miss; boardcast invalid to E; update to value %d\n", i, cache[i].value);
+                    printf("[%d] write miss; broadcast invalid to E; update to value %d\n", i, cache[i].value);
 #endif
                     return 1;
                 }
@@ -295,7 +295,7 @@ int write_cacheline(int i, int write_value)
                     cache[i].value = write_value;
 
 #ifdef DEBUG
-                    printf("[%d] write miss; boardcast invalid to S; update to value %d\n", i, cache[i].value);
+                    printf("[%d] write miss; broadcast invalid to S; update to value %d\n", i, cache[i].value);
 #endif
                     return 1;
                 }

--- a/src/process/pagefault.c
+++ b/src/process/pagefault.c
@@ -119,7 +119,7 @@ void pagemap_dirty(uint64_t ppn)
 }
 
 // used by frame swap-in from swap space
-// for newly allocated anoymous page
+// for newly allocated anonymous page
 void set_pagemap_swapaddr(uint64_t ppn, uint64_t swap_address)
 {
     assert(0 <= ppn && ppn < MAX_NUM_PHYSICAL_PAGE);

--- a/src/tests/test_rbt.c
+++ b/src/tests/test_rbt.c
@@ -311,7 +311,7 @@ static void test_delete()
     //  2. both sibling's childs black = (NULL, NULL)
     // double black gives black to parent
     // parent black, then parent double black, continue to parent, untill root
-    // silbing red
+    // sibling red
     r = rbt_construct_keystr(
         "(10,"
             "(5,(1,#,#),(7,#,#)),"
@@ -374,7 +374,7 @@ static void test_delete()
 
     // A COMPLETE TEST CASE
 
-    // silbing red
+    // sibling red
     r = rbt_construct_keystr(
         "(50,"
             "(20,(15,#,#),(35,#,#)),"


### PR DESCRIPTION
There are small typos in:
- src/hardware/memory/swap.c
- src/mains/mesi.c
- src/process/pagefault.c
- src/tests/test_rbt.c

Fixes:
- Should read `anonymous` rather than `anoymous`.
- Should read `sibling` rather than `silbing`.
- Should read `exactly` rather than `eaxctly`.
- Should read `broadcast` rather than `boardcast`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md